### PR TITLE
Use custom ffmpeg wrapper in conv service

### DIFF
--- a/nebula/log.py
+++ b/nebula/log.py
@@ -26,10 +26,13 @@ class Logger:
     def __call__(self, level: LogLevel, *args, **kwargs):
         if level < self.level:
             return
+
+        lvl = level.name.upper()
+        usr = kwargs.get("user") or self.user
+        msg = " ".join([str(arg) for arg in args])
+
         print(
-            f"{level.name.upper():<8}",
-            f"{kwargs.get('user') or self.user:<10}",
-            " ".join([str(arg) for arg in args]),
+            f"{lvl:<8} {usr:<12} {msg}",
             file=sys.stderr,
             flush=True,
         )

--- a/services/meta/ffprobe.py
+++ b/services/meta/ffprobe.py
@@ -9,10 +9,12 @@ from nebula.objects import Asset
 from nebula.settings import settings
 
 
-def string2cs(key, value):
+def string2cs(key: str, value: str):
     """Return a CS best matching for the given string."""
     nebula.log.info(f"Parsing {key} value {value}")
     cs = settings.metatypes[key].cs
+    if not cs:
+        return None
     vslug = slugify(value, separator=" ")
     best_match = None
     max_ratio = 0


### PR DESCRIPTION
Instead of relying on nxtools FFMPEG class, use custom wrapper for FFmpeg. It is based on the same code, but having it directly in conv service reduces complexity. Fixes can be propagated faster and we can use nebula logging.