### PR TITLE
Fail gracefully when a file is corrupted

### DIFF
--- a/services/import/process.py
+++ b/services/import/process.py
@@ -112,13 +112,19 @@ def import_asset(
 
     # Transcode
 
-    transcoder = ImportTranscoder(
-        import_file.path,
-        temp_file,
-        action.profile,
-    )
+    result = False
+    try:
+        transcoder = ImportTranscoder(
+            import_file.path,
+            temp_file,
+            action.profile,
+        )
 
-    result = transcoder.start(progress_handler)
+        result = transcoder.start(progress_handler)
+    except Exception as e:
+        # Result is still false, so job will fail
+        # We just log the problem
+        nebula.log.error(f"{e}")
 
     # Move temp file to asset file
 

--- a/services/import/transcoder.py
+++ b/services/import/transcoder.py
@@ -61,7 +61,10 @@ def mediainfo(path: str) -> MediaInfo:
     for track in data["media"]["track"]:
         index = track.get("StreamOrder", 0)
         if track["@type"] == "General":
-            duration = float(track["Duration"])
+            try:
+                duration = float(track["Duration"])
+            except (KeyError, ValueError):
+                raise Exception(f"Invalid source duration of {path}") from None
         elif track["@type"] == "Video":
             video_track = VideoTrack(
                 commercial_name=track.get("Format_Commercial_IfAny"),


### PR DESCRIPTION
When import service gets a corrupted file, handle the mediainfo exception gracefully and mark the job as failed instead of crashing